### PR TITLE
fix: revert fallback à "blocking" sur la page annonce

### DIFF
--- a/src/pages/annonce/[id].tsx
+++ b/src/pages/annonce/[id].tsx
@@ -402,7 +402,7 @@ export const getStaticPaths: GetStaticPaths<Params> = async () => {
 
   return {
     paths: products.docs.map((doc) => ({ params: { id: doc.id } })),
-    fallback: false,
+    fallback: "blocking",
   }
 }
 


### PR DESCRIPTION
Le passage à `fallback: false` (introduit dans #7, commit f7d9487) empêche le rendu de toute annonce créée après le dernier build : elle renvoie un 404 immédiat au lieu d'un rendu à la demande (ISR). On revient au comportement `"blocking"` d'origine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)