### PR TITLE
[IA] #221 Test IA change le titre générale par une calamboure drole écolo

### DIFF
--- a/src/components/Seo.tsx
+++ b/src/components/Seo.tsx
@@ -2,7 +2,7 @@ import Head from "next/head"
 
 const CONFIG = {
   title: "Les Choux d'à Côté",
-  tagline: "Vente directe : Le circuit plus court des produits alimentaires",
+  tagline: "Ne restez pas dans les choux : mangez local, mangez écolo !",
   description:
     "Les Choux d'à Côté - Producteurs, publiez gratuitement des annonces de vos produits. Acheteurs, découvrez les produits locaux près de chez vous.",
   image: process.env.NEXT_PUBLIC_URL + "/opengraph.jpg",

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -93,7 +93,7 @@ const HomePage = () => {
   return (
     <Layout bgImage>
       <Logo />
-      <Title>Vente directe : Le circuit plus court des produits alimentaires</Title>
+      <Title>Ne restez pas dans les choux : mangez local, mangez écolo !</Title>
       <a href="https://info.leschouxdacote.fr/" target="_blank" rel="noreferrer">
         <Introduction>
           <strong>Producteurs de produits alimentaires</strong>, augmentez vos <strong>ventes directes</strong> en


### PR DESCRIPTION
Ticket Trello : https://trello.com/c/er4rJCXl

Aucune occurrence résiduelle de l'ancien slogan, et `yarn tsc --skipLibCheck --noEmit` passe sans erreur.

**Résumé des changements :**
- `src/components/Seo.tsx:5` — `CONFIG.tagline` remplacé par le calembour écolo
- `src/pages/index.tsx:96` — H1 du hero de la page d'accueil mis à jour avec le même texte

Nouveau slogan : *« Ne restez pas dans les choux : mangez local, mangez écolo ! »* — un calembour sur l'expression « être dans les choux » (échouer), cohérent avec le nom de marque « Les Choux d'à Côté » et un message écolo/local. Le nom de marque, le footer, les emails et le manifest PWA n'ont pas été touchés, conformément au plan. Aucun commit n'a été fait.

🤖 Generated with [Claude Code](https://claude.com/claude-code)