### PR TITLE
[IA] #223 Change le titre pour une blague communiste

### DIFF
--- a/src/components/Seo.tsx
+++ b/src/components/Seo.tsx
@@ -1,8 +1,8 @@
 import Head from "next/head"
 
-const CONFIG = {
+export const CONFIG = {
   title: "Les Choux d'à Côté",
-  tagline: "Vente directe : Le circuit plus court des produits alimentaires",
+  tagline: "Sous le capitalisme, l'homme exploite l'homme. Sous le communisme, c'est l'inverse.",
   description:
     "Les Choux d'à Côté - Producteurs, publiez gratuitement des annonces de vos produits. Acheteurs, découvrez les produits locaux près de chez vous.",
   image: process.env.NEXT_PUBLIC_URL + "/opengraph.jpg",

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,5 +1,6 @@
 import styled from "@emotion/styled"
 import LogoSvg from "src/assets/logo.svg"
+import { CONFIG } from "src/components/Seo"
 import SearchBar, { BioSwitchLabelContainer } from "src/components/SearchBar"
 import { COLORS, LAYOUT } from "src/constants"
 import Layout from "src/layout"
@@ -93,7 +94,7 @@ const HomePage = () => {
   return (
     <Layout bgImage>
       <Logo />
-      <Title>Vente directe : Le circuit plus court des produits alimentaires</Title>
+      <Title>{CONFIG.tagline}</Title>
       <a href="https://info.leschouxdacote.fr/" target="_blank" rel="noreferrer">
         <Introduction>
           <strong>Producteurs de produits alimentaires</strong>, augmentez vos <strong>ventes directes</strong> en


### PR DESCRIPTION
Ticket Trello : https://trello.com/c/0UHAjW92

TypeScript ne remonte aucune erreur.

Résumé des changements :
- `src/components/Seo.tsx` — `CONFIG.tagline` exporté et remplacé par la blague communiste classique : *« Sous le capitalisme, l'homme exploite l'homme. Sous le communisme, c'est l'inverse. »* (affecte le `<title>` HTML et les meta og/twitter).
- `src/pages/index.tsx` — le H1 de la homepage importe désormais `CONFIG.tagline` depuis `Seo.tsx` au lieu de dupliquer le texte en dur, garantissant la cohérence entre l'onglet navigateur et le titre affiché.

`yarn tsc --skipLibCheck --noEmit` passe sans erreur. Aucun commit ni push effectué, comme demandé.

🤖 Generated with [Claude Code](https://claude.com/claude-code)