### PR TITLE
[IA] #225 Modifier l'ordre dans lequel s'affiche les annonces

### DIFF
--- a/src/helpers/geo.ts
+++ b/src/helpers/geo.ts
@@ -12,6 +12,7 @@ export const distance = (a: Geoloc, b: Geoloc) => {
   const dLat = ((b.lat - a.lat) * Math.PI) / 180
   const dLng = ((b.lng - a.lng) * Math.PI) / 180
   const h =
-    Math.sin(dLat / 2) ** 2 + Math.cos((a.lat * Math.PI) / 180) * Math.cos((b.lat * Math.PI) / 180) * Math.sin(dLng / 2) ** 2
+    Math.sin(dLat / 2) ** 2 +
+    Math.cos((a.lat * Math.PI) / 180) * Math.cos((b.lat * Math.PI) / 180) * Math.sin(dLng / 2) ** 2
   return 2 * EARTH_RADIUS_KM * Math.asin(Math.sqrt(h))
 }

--- a/src/helpers/geo.ts
+++ b/src/helpers/geo.ts
@@ -1,0 +1,17 @@
+import type { Geoloc } from "src/types/model"
+
+const EARTH_RADIUS_KM = 6371
+
+export const parseLatLng = (ll: string): Geoloc => {
+  const [lat, lng] = ll.split(",").map(Number)
+  return { lat, lng }
+}
+
+// Haversine distance, in km — only used to sort by proximity, not to display a value
+export const distance = (a: Geoloc, b: Geoloc) => {
+  const dLat = ((b.lat - a.lat) * Math.PI) / 180
+  const dLng = ((b.lng - a.lng) * Math.PI) / 180
+  const h =
+    Math.sin(dLat / 2) ** 2 + Math.cos((a.lat * Math.PI) / 180) * Math.cos((b.lat * Math.PI) / 180) * Math.sin(dLng / 2) ** 2
+  return 2 * EARTH_RADIUS_KM * Math.asin(Math.sqrt(h))
+}

--- a/src/pages/recherche.tsx
+++ b/src/pages/recherche.tsx
@@ -10,6 +10,7 @@ import ResultsMap from "src/components/ResultsMap"
 import { COLORS, SEARCH_RADIUS } from "src/constants"
 import { productsIndex } from "src/helpers/algolia"
 import { handleError } from "src/helpers/errors"
+import { distance, parseLatLng } from "src/helpers/geo"
 import { HoverProvider } from "src/helpers/hover"
 import Layout from "src/layout"
 import { ProductEncoded } from "src/models/Product"
@@ -52,6 +53,15 @@ const getOptions = (radius: number, latlng?: string, bio?: "1") => {
   return options
 }
 
+// La proximité avec la ville recherchée est prioritaire sur le ranking Algolia (typo, custom ranking, etc.)
+const sortByProximity = (hits: ProductEncoded[], latlng?: string) => {
+  if (!latlng) {
+    return hits
+  }
+  const origin = parseLatLng(latlng)
+  return [...hits].sort((a, b) => distance(origin, a._geoloc) - distance(origin, b._geoloc))
+}
+
 const SearchPage = () => {
   const { query, isReady } = useRouter()
   const [view, setView] = useState<"list" | "map" | "both">("list")
@@ -72,7 +82,7 @@ const SearchPage = () => {
     }
     productsIndex
       .search<ProductEncoded>(what || "", getOptions(radius, ll, bio))
-      .then(({ hits }) => setResults(hits))
+      .then(({ hits }) => setResults(sortByProximity(hits, ll)))
       .catch(handleError)
   }, [isReady, what, radius, ll, bio])
 


### PR DESCRIPTION
Ticket Trello : https://trello.com/c/0I9V7YHm

Le code respecte le style du projet (pas de point-virgule, imports triés, printWidth 120). L'implémentation est complète :

- **`src/helpers/geo.ts`** (nouveau) : `parseLatLng` et `distance` (Haversine).
- **`src/pages/recherche.tsx`** : les résultats sont désormais triés par proximité croissante à la ville recherchée (`sortByProximity`) quand `ll` est présent dans la query ; sans ville saisie, l'ordre Algolia habituel est conservé.
- `yarn tsc --skipLibCheck --noEmit` passe sans erreur.

Aucun commit ni push effectué, comme demandé.

🤖 Generated with [Claude Code](https://claude.com/claude-code)