### PR TITLE
[IA] #89 Photo grande hauteur qui se couche

### DIFF
--- a/src/helpers-api/image.ts
+++ b/src/helpers-api/image.ts
@@ -39,6 +39,7 @@ export const resize = async (source: string) => {
   const destination = source + "-resized.jpg"
 
   await image
+    .rotate()
     .resize({ width: WIDTH, withoutEnlargement: true })
     .toFormat("jpeg", { quality: QUALITY })
     .toFile(destination)


### PR DESCRIPTION
Ticket Trello : https://trello.com/c/vTnItdeo

`tsc --skipLibCheck --noEmit` passe sans erreur. Le correctif est un ajout d'une seule ligne (`.rotate()` avant `.resize()`) dans `src/helpers-api/image.ts:41-45`, comme prévu au plan. Aucun commit effectué.

🤖 Generated with [Claude Code](https://claude.com/claude-code)