### PR TITLE
[IA] #185 Mot-clé : obligatoire pour valider une annonce

### DIFF
--- a/src/components/TagsInput.tsx
+++ b/src/components/TagsInput.tsx
@@ -2,7 +2,7 @@ import styled from "@emotion/styled"
 import { ChangeEvent, FocusEvent, KeyboardEvent, useRef, useState } from "react"
 import { useFormContext } from "react-hook-form"
 import CustomSwitch from "src/components/CustomSwitch"
-import { Label } from "src/components/Form"
+import { ErrorMessage, Label } from "src/components/Form"
 import { COLORS } from "src/constants"
 import { tagsIndex } from "src/helpers/algolia"
 
@@ -46,11 +46,12 @@ interface Props {
 }
 
 const TagsInput = ({ label }: Props) => {
-  const { register, getValues, setValue, watch } = useFormContext()
+  const { register, getValues, setValue, watch, formState } = useFormContext()
   const inputRef = useRef<HTMLInputElement>(null)
   const [suggestions, setSuggestions] = useState<AlgoliaTag[]>([])
   register("_tags")
   const values: string[] = watch("_tags") || []
+  const error = formState.errors["_tags"]
 
   const add = (value: string) => {
     setValue("_tags", [...values, value])
@@ -103,8 +104,8 @@ const TagsInput = ({ label }: Props) => {
   }
 
   return (
-    <Label htmlFor={"_tags"}>
-      <div>{label}</div>
+    <Label htmlFor={"_tags"} $error={Boolean(error)}>
+      <div>{label} *</div>
       <label>
         <CustomSwitch name="bio" defaultChecked={getValues("bio")} /> Bio ou agriculture raisonnée
       </label>
@@ -137,6 +138,7 @@ const TagsInput = ({ label }: Props) => {
           ))}
         </Suggestions>
       )}
+      {error && <ErrorMessage>{error.message?.toString()}</ErrorMessage>}
     </Label>
   )
 }

--- a/src/pages/api/product.ts
+++ b/src/pages/api/product.ts
@@ -37,6 +37,11 @@ const handler = async (req: NextApiRequest, res: NextApiResponse<ApiResponse<Reg
         address: "Vous devez sélectionner une adresse suggérée par Google dans la liste déroulante",
       })
     }
+    if (!fields._tags) {
+      return respond(res, {
+        _tags: "Veuillez renseigner au moins un mot-clé.",
+      })
+    }
     if (!fields.email && !fields.phone) {
       return respond(res, {
         email: "Vous devez au moins spécifier une adresse e-mail ou un numéro de téléphone",

--- a/src/pages/compte/producteur/annonce/index.tsx
+++ b/src/pages/compte/producteur/annonce/index.tsx
@@ -108,6 +108,10 @@ const EditProductPage = () => {
       throw new ValidationError("address", "Veuillez sélectionner l'adresse dans la liste déroulante")
     }
 
+    if (!payload.get("_tags")) {
+      throw new ValidationError("_tags", "Veuillez renseigner au moins un mot-clé.")
+    }
+
     if (payload.get("days") === "0") {
       const ok = confirm("Êtes-vous sûr·e de ne pas vouloir publier cette annonce ?\n(durée renseignée : 0 jours)")
       if (!ok) {


### PR DESCRIPTION
Ticket Trello : https://trello.com/c/1k2fuhoh

Le diff correspond exactement au plan validé. Récapitulatif :

- **`src/components/TagsInput.tsx`** : lecture de `formState.errors["_tags"]`, coloration rouge du label (`$error`), astérisque `*` ajouté au libellé, message d'erreur affiché sous le champ.
- **`src/pages/compte/producteur/annonce/index.tsx`** : blocage côté client à la soumission si aucun mot-clé (`ValidationError("_tags", "Veuillez renseigner au moins un mot-clé.")`).
- **`src/pages/api/product.ts`** : garde-fou serveur identique (mêmes clé de champ et message).
- `src/models/Product.ts` volontairement inchangé (annonces existantes sans mot-clé restent affichables).

`yarn tsc --skipLibCheck --noEmit` passe sans erreur. Aucun commit ni push effectué, comme demandé.

🤖 Generated with [Claude Code](https://claude.com/claude-code)