### PR TITLE
[IA] #216 Le producteur active la réservation

### DIFF
--- a/src/components/Reservation.tsx
+++ b/src/components/Reservation.tsx
@@ -84,8 +84,6 @@ const ReservationBlock = ({ slot, index, slots, setSlots }: ReservationBlockProp
 
   return (
     <Stack spacing={1} alignItems="start" width="100%" mb={2}>
-      <Typography variant="h6">Stock</Typography>
-
       {!isOpen && (
         <Button variant="contained" color="primary" onClick={handleCreate}>
           Créer une réservation
@@ -94,6 +92,16 @@ const ReservationBlock = ({ slot, index, slots, setSlots }: ReservationBlockProp
 
       {isOpen && (
         <>
+          <Typography variant="h6">Informations et instructions</Typography>
+          <TextField
+            multiline
+            fullWidth
+            value={instructions}
+            onChange={(event) => setInstructions(event.target.value)}
+          />
+
+          <Typography variant="h6">Stock</Typography>
+
           <Box>
             <TextField
               label="Quantité totale *"
@@ -127,14 +135,6 @@ const ReservationBlock = ({ slot, index, slots, setSlots }: ReservationBlockProp
               Veuillez renseigner l&apos;unité du produit ci-dessus pour activer cette réservation.
             </Typography>
           )}
-
-          <TextField
-            label="Informations et instructions"
-            multiline
-            fullWidth
-            value={instructions}
-            onChange={(event) => setInstructions(event.target.value)}
-          />
 
           {error && (
             <Typography color="error" variant="body2">

--- a/src/components/Reservation.tsx
+++ b/src/components/Reservation.tsx
@@ -1,0 +1,159 @@
+import { Box, Button, Stack, TextField, Typography } from "@mui/material"
+import { Either as E, ParseResult, pipe, Schema as Sc } from "effect"
+import React, { useState } from "react"
+import { useFormContext } from "react-hook-form"
+import { Reservation, ReservationSchema, Slot } from "src/pages/compte/producteur/annonce"
+import type { Unit } from "src/types/model"
+
+const UNIT_LABELS: Record<Unit, string> = {
+  g: "g",
+  kg: "kg",
+  l: "litre(s)",
+  u: "pièce(s)",
+}
+
+interface ReservationBlockProps {
+  slot: Slot
+  index: number
+  slots: readonly Slot[]
+  setSlots: React.Dispatch<React.SetStateAction<readonly Slot[]>>
+}
+
+const ReservationBlock = ({ slot, index, slots, setSlots }: ReservationBlockProps) => {
+  const { watch } = useFormContext()
+  const unit = watch("unit") as Unit | null | undefined
+
+  const [isOpen, setIsOpen] = useState(Boolean(slot.reservation))
+  const [totalQuantity, setTotalQuantity] = useState(slot.reservation ? String(slot.reservation.totalQuantity) : "")
+  const [maxQuantityPerPerson, setMaxQuantityPerPerson] = useState(
+    slot.reservation?.maxQuantityPerPerson != null ? String(slot.reservation.maxQuantityPerPerson) : "",
+  )
+  const [instructions, setInstructions] = useState(slot.reservation?.instructions ?? "")
+  const [error, setError] = useState<string | null>(null)
+
+  const updateSlot = (reservation: Reservation | null) => {
+    setSlots(slots.map((s, i) => (i === index ? { ...s, reservation } : s)))
+  }
+
+  const handleCreate = () => {
+    setIsOpen(true)
+  }
+
+  const handleDelete = () => {
+    setIsOpen(false)
+    setTotalQuantity("")
+    setMaxQuantityPerPerson("")
+    setInstructions("")
+    setError(null)
+    updateSlot(null)
+  }
+
+  const handleValidate = () => {
+    pipe(
+      Sc.decodeUnknownEither(
+        pipe(
+          ReservationSchema,
+          Sc.filter((reservation) => {
+            if (!Number.isFinite(reservation.totalQuantity) || reservation.totalQuantity <= 0) {
+              return "La quantité totale doit être supérieur à 0."
+            }
+            if (
+              reservation.maxQuantityPerPerson != null &&
+              reservation.maxQuantityPerPerson > reservation.totalQuantity
+            ) {
+              return "La quantité max/personne dépasse la quantité totale."
+            }
+            return true
+          }),
+        ),
+      )({
+        totalQuantity: Number(totalQuantity),
+        maxQuantityPerPerson: maxQuantityPerPerson === "" ? null : Number(maxQuantityPerPerson),
+        instructions: instructions || null,
+      }),
+
+      E.map((reservation) => {
+        setError(null)
+        updateSlot(reservation)
+      }),
+
+      E.mapLeft((error) => ParseResult.ArrayFormatter.formatErrorSync(error)),
+      E.mapLeft((error) => setError(error[0].message)),
+    )
+  }
+
+  return (
+    <Stack spacing={1} alignItems="start" width="100%" mb={2}>
+      <Typography variant="h6">Stock</Typography>
+
+      {!isOpen && (
+        <Button variant="contained" color="primary" onClick={handleCreate}>
+          Créer une réservation
+        </Button>
+      )}
+
+      {isOpen && (
+        <>
+          <Box>
+            <TextField
+              label="Quantité totale *"
+              type="number"
+              inputProps={{ min: 1, step: 1 }}
+              value={totalQuantity}
+              onChange={(event) => setTotalQuantity(event.target.value)}
+            />
+          </Box>
+          <Typography variant="body2" color="textSecondary">
+            {`Au bout de ${totalQuantity || 0} quantités réservées, la réservation ne sera plus possible.`}
+          </Typography>
+
+          <Box>
+            <TextField
+              label="Quantité réservable maximale par personne"
+              type="number"
+              inputProps={{ min: 1, step: 1 }}
+              value={maxQuantityPerPerson}
+              onChange={(event) => setMaxQuantityPerPerson(event.target.value)}
+            />
+          </Box>
+          <Typography variant="body2" color="textSecondary">
+            Si ce champ n&apos;est pas rempli, il n&apos;y a pas de limite maximale.
+          </Typography>
+
+          {unit ? (
+            <Typography variant="body2">Unité : {UNIT_LABELS[unit]}</Typography>
+          ) : (
+            <Typography variant="body2" color="error">
+              Veuillez renseigner l&apos;unité du produit ci-dessus pour activer cette réservation.
+            </Typography>
+          )}
+
+          <TextField
+            label="Informations et instructions"
+            multiline
+            fullWidth
+            value={instructions}
+            onChange={(event) => setInstructions(event.target.value)}
+          />
+
+          {error && (
+            <Typography color="error" variant="body2">
+              {error}
+            </Typography>
+          )}
+
+          <Stack direction="row" spacing={2}>
+            <Button variant="contained" color="primary" onClick={handleValidate}>
+              Valider
+            </Button>
+            <Button variant="outlined" color="error" onClick={handleDelete}>
+              Supprimer cette réservation
+            </Button>
+          </Stack>
+        </>
+      )}
+    </Stack>
+  )
+}
+
+export default ReservationBlock

--- a/src/components/Reservation.tsx
+++ b/src/components/Reservation.tsx
@@ -1,4 +1,4 @@
-import { Box, Button, Stack, TextField, Typography } from "@mui/material"
+import { Box, Button, Divider, Stack, TextField, Typography } from "@mui/material"
 import { Either as E, ParseResult, pipe, Schema as Sc } from "effect"
 import React, { useState } from "react"
 import { useFormContext } from "react-hook-form"
@@ -30,6 +30,7 @@ const ReservationBlock = ({ slot, index, slots, setSlots }: ReservationBlockProp
   )
   const [instructions, setInstructions] = useState(slot.reservation?.instructions ?? "")
   const [error, setError] = useState<string | null>(null)
+  const [isValidated, setIsValidated] = useState(Boolean(slot.reservation))
 
   const updateSlot = (reservation: Reservation | null) => {
     setSlots(slots.map((s, i) => (i === index ? { ...s, reservation } : s)))
@@ -45,6 +46,7 @@ const ReservationBlock = ({ slot, index, slots, setSlots }: ReservationBlockProp
     setMaxQuantityPerPerson("")
     setInstructions("")
     setError(null)
+    setIsValidated(false)
     updateSlot(null)
   }
 
@@ -74,6 +76,7 @@ const ReservationBlock = ({ slot, index, slots, setSlots }: ReservationBlockProp
 
       E.map((reservation) => {
         setError(null)
+        setIsValidated(true)
         updateSlot(reservation)
       }),
 
@@ -81,6 +84,8 @@ const ReservationBlock = ({ slot, index, slots, setSlots }: ReservationBlockProp
       E.mapLeft((error) => setError(error[0].message)),
     )
   }
+
+  const statusText = isValidated ? "validé" : "brouillon"
 
   return (
     <Stack spacing={1} alignItems="start" width="100%" mb={2}>
@@ -92,6 +97,8 @@ const ReservationBlock = ({ slot, index, slots, setSlots }: ReservationBlockProp
 
       {isOpen && (
         <>
+          <Typography variant="body2">Statut de la réservation : {statusText}</Typography>
+
           <Typography variant="h6">Informations et instructions</Typography>
           <TextField
             multiline
@@ -102,35 +109,49 @@ const ReservationBlock = ({ slot, index, slots, setSlots }: ReservationBlockProp
 
           <Typography variant="h6">Stock</Typography>
 
-          <Box>
-            <TextField
-              label="Quantité totale *"
-              type="number"
-              inputProps={{ min: 1, step: 1 }}
-              value={totalQuantity}
-              onChange={(event) => setTotalQuantity(event.target.value)}
-            />
-          </Box>
+          <Stack direction="row" spacing={2} alignItems="center" width="100%">
+            <Box flex={1}>
+              <TextField
+                label="Quantité totale *"
+                type="number"
+                inputProps={{ min: 1, step: 1 }}
+                value={totalQuantity}
+                onChange={(event) => setTotalQuantity(event.target.value)}
+                fullWidth
+              />
+            </Box>
+            {unit && (
+              <Box>
+                <Typography variant="body1">{UNIT_LABELS[unit]}</Typography>
+              </Box>
+            )}
+          </Stack>
           <Typography variant="body2" color="textSecondary">
             {`Au bout de ${totalQuantity || 0} quantités réservées, la réservation ne sera plus possible.`}
           </Typography>
 
-          <Box>
-            <TextField
-              label="Quantité réservable maximale par personne"
-              type="number"
-              inputProps={{ min: 1, step: 1 }}
-              value={maxQuantityPerPerson}
-              onChange={(event) => setMaxQuantityPerPerson(event.target.value)}
-            />
-          </Box>
+          <Stack direction="row" spacing={2} alignItems="center" width="100%">
+            <Box flex={1}>
+              <TextField
+                label="Quantité réservable maximale par personne"
+                type="number"
+                inputProps={{ min: 1, step: 1 }}
+                value={maxQuantityPerPerson}
+                onChange={(event) => setMaxQuantityPerPerson(event.target.value)}
+                fullWidth
+              />
+            </Box>
+            {unit && (
+              <Box>
+                <Typography variant="body1">{UNIT_LABELS[unit]}</Typography>
+              </Box>
+            )}
+          </Stack>
           <Typography variant="body2" color="textSecondary">
             Si ce champ n&apos;est pas rempli, il n&apos;y a pas de limite maximale.
           </Typography>
 
-          {unit ? (
-            <Typography variant="body2">Unité : {UNIT_LABELS[unit]}</Typography>
-          ) : (
+          {!unit && (
             <Typography variant="body2" color="error">
               Veuillez renseigner l&apos;unité du produit ci-dessus pour activer cette réservation.
             </Typography>
@@ -150,6 +171,7 @@ const ReservationBlock = ({ slot, index, slots, setSlots }: ReservationBlockProp
               Supprimer cette réservation
             </Button>
           </Stack>
+          <Divider sx={{ my: 2, borderColor: "#666666" }} />
         </>
       )}
     </Stack>

--- a/src/components/Slots.tsx
+++ b/src/components/Slots.tsx
@@ -6,6 +6,7 @@ import { Controller, useForm } from "react-hook-form"
 import { Either as E, ParseResult, pipe, Schema as Sc } from "effect"
 import { Slot, SlotSchema } from "src/pages/compte/producteur/annonce"
 import Modal from "src/components/Modal"
+import ReservationBlock from "src/components/Reservation"
 
 interface SlotsFormProps {
   slots: readonly Slot[]
@@ -44,26 +45,29 @@ const SlotsForm = ({ setSlots, slots }: SlotsFormProps) => {
       <h2>Créneaux</h2>
 
       {slots.map((slot, index) => (
-        <Stack direction="row" spacing={2} alignItems="center" width="100%" mb={2} key={index}>
-          <Box width="37%">
-            <Typography variant="body1">{`Le ${slot.date.toLocaleDateString()}`}</Typography>
-          </Box>
-          <Box width="23%" paddingLeft={"6px"}>
-            <Typography variant="body1">{` de ${slot.heureDebut}`}</Typography>
-          </Box>
-          <Box width="23%" paddingLeft={"6px"}>
-            <Typography variant="body1">{`à ${slot.heureFin}`}</Typography>
-          </Box>
-          <Box width="17%">
-            <IconButton
-              onClick={() => {
-                handleDeleteClick(slot)
-              }}
-            >
-              <RemoveCircle color="error" />
-            </IconButton>
-          </Box>
-        </Stack>
+        <React.Fragment key={index}>
+          <Stack direction="row" spacing={2} alignItems="center" width="100%" mb={2}>
+            <Box width="37%">
+              <Typography variant="body1">{`Le ${slot.date.toLocaleDateString()}`}</Typography>
+            </Box>
+            <Box width="23%" paddingLeft={"6px"}>
+              <Typography variant="body1">{` de ${slot.heureDebut}`}</Typography>
+            </Box>
+            <Box width="23%" paddingLeft={"6px"}>
+              <Typography variant="body1">{`à ${slot.heureFin}`}</Typography>
+            </Box>
+            <Box width="17%">
+              <IconButton
+                onClick={() => {
+                  handleDeleteClick(slot)
+                }}
+              >
+                <RemoveCircle color="error" />
+              </IconButton>
+            </Box>
+          </Stack>
+          <ReservationBlock slot={slot} index={index} slots={slots} setSlots={setSlots} />
+        </React.Fragment>
       ))}
       {error && (
         <Typography color="error" variant="body1">

--- a/src/components/Slots.tsx
+++ b/src/components/Slots.tsx
@@ -42,7 +42,9 @@ const SlotsForm = ({ setSlots, slots }: SlotsFormProps) => {
 
   return (
     <Stack spacing={2} alignItems="start">
-      <h2>Créneaux</h2>
+      <Typography variant="h2" sx={{ fontSize: "25px" }}>
+        Créneaux
+      </Typography>
 
       {slots.map((slot, index) => (
         <React.Fragment key={index}>

--- a/src/pages/api/product.ts
+++ b/src/pages/api/product.ts
@@ -95,6 +95,12 @@ const handler = async (req: NextApiRequest, res: NextApiResponse<ApiResponse<Reg
     const position = { lat: Number(fields.lat), lng: Number(fields.lng) }
     console.log(slots.map((a) => a))
 
+    if (slots.some((slot) => slot.reservation != null) && !fields.unit) {
+      return respond(res, {
+        unit: "L'unité est obligatoire pour activer une réservation.",
+      })
+    }
+
     const product: RegisteringProduct = {
       created: existing ? new Date(existing.created) : now,
       uid: fields.uid,

--- a/src/pages/compte/producteur/annonce/index.tsx
+++ b/src/pages/compte/producteur/annonce/index.tsx
@@ -29,10 +29,19 @@ const SlotDate = Sc.DateFromString.annotations({
   override: true,
 })
 
+export const ReservationSchema = Sc.Struct({
+  totalQuantity: Sc.Number,
+  maxQuantityPerPerson: Sc.optional(Sc.NullOr(Sc.Number)),
+  instructions: Sc.optional(Sc.NullOr(Sc.String)),
+})
+
+export type Reservation = typeof ReservationSchema.Type
+
 export const SlotSchema = Sc.Struct({
   date: SlotDate,
   heureDebut: Sc.String,
   heureFin: Sc.String,
+  reservation: Sc.optional(Sc.NullOr(ReservationSchema)),
 })
 
 export type Slot = typeof SlotSchema.Type
@@ -53,6 +62,7 @@ export const SlotSchemaFirestore = Sc.Struct({
   date: SlotDateFirestore,
   heureDebut: Sc.String,
   heureFin: Sc.String,
+  reservation: Sc.optional(Sc.NullOr(ReservationSchema)),
 })
 
 export type SlotSchemaFirestore = typeof SlotSchemaFirestore.Type
@@ -106,6 +116,10 @@ const EditProductPage = () => {
 
     if (!place) {
       throw new ValidationError("address", "Veuillez sélectionner l'adresse dans la liste déroulante")
+    }
+
+    if (slots.some((slot) => slot.reservation != null) && !payload.get("unit")) {
+      throw new ValidationError("unit", "L'unité est obligatoire pour activer une réservation.")
     }
 
     if (payload.get("days") === "0") {

--- a/src/pages/compte/producteur/annonce/index.tsx
+++ b/src/pages/compte/producteur/annonce/index.tsx
@@ -29,6 +29,8 @@ const TwoColumnLayout = styled.div`
   display: grid;
   grid-template-columns: 1fr 1fr;
   gap: 40px;
+  width: 100%;
+  max-width: ${1100}px;
 
   @media (max-width: 900px) {
     grid-template-columns: 1fr;
@@ -204,15 +206,15 @@ const EditProductPage = () => {
 
   return (
     <Layout title={title} loading={loading}>
-      <TwoColumnLayout>
-        <LeftColumn>
-          <Form
-            title={title}
-            hasRequired
-            onSubmit={handleSubmit}
-            defaultValues={defaultValues}
-            resetOnChange={data?.objectID}
-          >
+      <Form
+        title={title}
+        hasRequired
+        onSubmit={handleSubmit}
+        defaultValues={defaultValues}
+        resetOnChange={data?.objectID}
+      >
+        <TwoColumnLayout>
+          <LeftColumn>
             <TextInput name="title" label="Titre" required maxLength={100} />
             <Row>
               <TextInput name="quantity" label="Quantité" type="number" min={0} step={0.01} />
@@ -264,12 +266,12 @@ const EditProductPage = () => {
             />
             <ProductEndDate />
             <SubmitButton />
-          </Form>
-        </LeftColumn>
-        <RightColumn>
-          <SlotsForm setSlots={setSlots} slots={slots} />
-        </RightColumn>
-      </TwoColumnLayout>
+          </LeftColumn>
+          <RightColumn>
+            <SlotsForm setSlots={setSlots} slots={slots} />
+          </RightColumn>
+        </TwoColumnLayout>
+      </Form>
     </Layout>
   )
 }

--- a/src/pages/compte/producteur/annonce/index.tsx
+++ b/src/pages/compte/producteur/annonce/index.tsx
@@ -24,6 +24,20 @@ const ACCEPTED_MIMETYPES = ["image/jpeg", "image/png", "image/webp", "image/tiff
 const Photo = styled.img`
   width: 100%;
 `
+
+const TwoColumnLayout = styled.div`
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 40px;
+
+  @media (max-width: 900px) {
+    grid-template-columns: 1fr;
+  }
+`
+
+const LeftColumn = styled.div``
+
+const RightColumn = styled.div``
 const SlotDate = Sc.DateFromString.annotations({
   message: () => "Veuillez entrer une date.",
   override: true,
@@ -190,66 +204,72 @@ const EditProductPage = () => {
 
   return (
     <Layout title={title} loading={loading}>
-      <Form
-        title={title}
-        hasRequired
-        onSubmit={handleSubmit}
-        defaultValues={defaultValues}
-        resetOnChange={data?.objectID}
-      >
-        <TextInput name="title" label="Titre" required maxLength={100} />
-        <Row>
-          <TextInput name="quantity" label="Quantité" type="number" min={0} step={0.01} />
-          <SelectInput name="unit" label="Unité">
-            <option></option>
-            <option value="g">g</option>
-            <option value="kg">kg</option>
-            <option value="l">litre(s)</option>
-            <option value="u">pièce(s)</option>
-          </SelectInput>
-        </Row>
-        <TextInput name="price" label="Prix total" required type="number" min={0} step={0.01} suffix="euros" />
-        <PriceInfos />
-        <TextInput
-          name="address"
-          label="Adresse de la vente (ferme, magasin, marché, point de distribution…)"
-          required
-          placeholder=""
-          id="place"
-          ref={handleRef}
-        />
-        <TextInput name="description" label="Description" required rows={8} maxLength={4000} />
-        <TagsInput label="Mots-clés" />
-        {data && <Photo src={data.photo} />}
-        <TextInput
-          name="photo"
-          label={productId ? "Changer la photo" : "Photo"}
-          type="file"
-          required={productId ? false : true}
-          accept={ACCEPTED_MIMETYPES.join(",")}
-        />
-        <TextInput type="email" name="email" label="Adresse e-mail" defaultValue={authUser?.email} />
-        <TextInput
-          type="tel"
-          name="phone"
-          label="Téléphone"
-          validate={validatePhoneNumber}
-          defaultValue={user?.phone}
-        />
-        <TextInput
-          name="days"
-          label="Publier maintenant pour une durée de :"
-          type="number"
-          min={0}
-          max={MAX_PUBLICATION_DAYS}
-          step={1}
-          defaultValue={0}
-          suffix="jour(s)"
-        />
-        <ProductEndDate />
-        <SlotsForm setSlots={setSlots} slots={slots} />
-        <SubmitButton />
-      </Form>
+      <TwoColumnLayout>
+        <LeftColumn>
+          <Form
+            title={title}
+            hasRequired
+            onSubmit={handleSubmit}
+            defaultValues={defaultValues}
+            resetOnChange={data?.objectID}
+          >
+            <TextInput name="title" label="Titre" required maxLength={100} />
+            <Row>
+              <TextInput name="quantity" label="Quantité" type="number" min={0} step={0.01} />
+              <SelectInput name="unit" label="Unité">
+                <option></option>
+                <option value="g">g</option>
+                <option value="kg">kg</option>
+                <option value="l">litre(s)</option>
+                <option value="u">pièce(s)</option>
+              </SelectInput>
+            </Row>
+            <TextInput name="price" label="Prix total" required type="number" min={0} step={0.01} suffix="euros" />
+            <PriceInfos />
+            <TextInput
+              name="address"
+              label="Adresse de la vente (ferme, magasin, marché, point de distribution…)"
+              required
+              placeholder=""
+              id="place"
+              ref={handleRef}
+            />
+            <TextInput name="description" label="Description" required rows={8} maxLength={4000} />
+            <TagsInput label="Mots-clés" />
+            {data && <Photo src={data.photo} />}
+            <TextInput
+              name="photo"
+              label={productId ? "Changer la photo" : "Photo"}
+              type="file"
+              required={productId ? false : true}
+              accept={ACCEPTED_MIMETYPES.join(",")}
+            />
+            <TextInput type="email" name="email" label="Adresse e-mail" defaultValue={authUser?.email} />
+            <TextInput
+              type="tel"
+              name="phone"
+              label="Téléphone"
+              validate={validatePhoneNumber}
+              defaultValue={user?.phone}
+            />
+            <TextInput
+              name="days"
+              label="Publier maintenant pour une durée de :"
+              type="number"
+              min={0}
+              max={MAX_PUBLICATION_DAYS}
+              step={1}
+              defaultValue={0}
+              suffix="jour(s)"
+            />
+            <ProductEndDate />
+            <SubmitButton />
+          </Form>
+        </LeftColumn>
+        <RightColumn>
+          <SlotsForm setSlots={setSlots} slots={slots} />
+        </RightColumn>
+      </TwoColumnLayout>
     </Layout>
   )
 }


### PR DESCRIPTION
Ticket Trello : https://trello.com/c/3E7hPZ14

`yarn tsc --skipLibCheck --noEmit` passe sans erreur. Résumé des changements (aucun commit fait, comme demandé) :

- **`src/pages/compte/producteur/annonce/index.tsx`** : ajout de `ReservationSchema` (`totalQuantity`, `maxQuantityPerPerson?`, `instructions?`) et extension de `SlotSchema`/`SlotSchemaFirestore` avec `reservation`. Ajout du contrôle "unité obligatoire si réservation active" dans `handleSubmit`.
- **`src/components/Reservation.tsx`** (nouveau) : composant `ReservationBlock` par créneau — bascule Créer/Supprimer, champs Quantité totale/Quantité max par personne avec textes d'aide dynamiques, unité en lecture seule (dérivée du champ produit `unit` via `useFormContext`) ou message d'alerte si non renseignée, zone de texte auto-redimensionnable (MUI `TextField multiline`), bouton Valider avec les deux messages d'erreur du ticket.
- **`src/components/Slots.tsx`** : intégration de `ReservationBlock` sous chaque ligne de créneau.
- **`src/pages/api/product.ts`** : contrôle serveur miroir (unité obligatoire si une réservation est active).

Points restés volontairement hors périmètre (conformes aux échanges Trello) : flux acheteur, décrémentation de stock, nouvelle collection Firestore.

🤖 Generated with [Claude Code](https://claude.com/claude-code)