### PR TITLE
[IA] #201 Sécuriser accès aux données des producteurs

### DIFF
--- a/src/components/UserZone.tsx
+++ b/src/components/UserZone.tsx
@@ -89,6 +89,7 @@ const UserZone = () => {
         {open && (
           <Menu>
             {user?.role === USER_ROLE.PRODUCER && <Entry href="/compte/producteur/annonces">Mes annonces</Entry>}
+            {user?.isAdmin && <Entry href="/csv-export">Export des CSVs</Entry>}
             <Entry href="/compte/profil">Mon profil</Entry>
             <Entry href="/compte/alertes">Mes alertes</Entry>
             <Logout onClick={signout}>Se déconnecter</Logout>

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -42,7 +42,6 @@ export const COLORS = {
 export enum USER_ROLE {
   PRODUCER = "PRODUCER",
   BUYER = "BUYER",
-  ADMIN = "ADMIN",
 }
 
 export const BIO = "_bio"

--- a/src/helpers/auth.tsx
+++ b/src/helpers/auth.tsx
@@ -92,14 +92,11 @@ export const UserProvider = ({ children }: { children: React.ReactNode }) => {
     if (authUser && user?.role === USER_ROLE.BUYER && ANONYMOUS_ROUTES.includes(pathname)) {
       return destination || "/"
     }
-    if (authUser && user?.role === USER_ROLE.ADMIN && ANONYMOUS_ROUTES.includes(pathname)) {
-      return "/csv-export"
-    }
 
-    if (!authUser && isPrivateRoute) {
+    if (!authUser && (isPrivateRoute || ADMIN_ROUTES.includes(pathname))) {
       return "/connexion?next=" + asPath
     }
-    if (authUser && user?.role !== USER_ROLE.ADMIN && ADMIN_ROUTES.includes(pathname)) {
+    if (authUser && user && !user.isAdmin && ADMIN_ROUTES.includes(pathname)) {
       return "/"
     }
   })()

--- a/src/layout/header.tsx
+++ b/src/layout/header.tsx
@@ -117,11 +117,6 @@ const Header = () => {
             Créer une annonce
           </Cta>
         )}
-        {user?.role === USER_ROLE.ADMIN && (
-          <Cta href="/csv-export" $variant="red">
-            Export des CSVs
-          </Cta>
-        )}
 
         <UserZone />
       </Desktop>

--- a/src/pages/api/export.ts
+++ b/src/pages/api/export.ts
@@ -4,13 +4,19 @@ import { USER_ROLE } from "src/constants"
 
 import getCsv from "src/helpers-api/csv"
 import { firestore, getObject, getToken } from "src/helpers-api/firebase"
-import type { Producer, Product } from "src/types/model"
+import type { Producer, Product, User } from "src/types/model"
 
 const handler = async (req: NextApiRequest, res: NextApiResponse<string>) => {
   const query = req.query.q
   const token = await getToken(req)
 
-  if (!token || token.email !== "cilieff@gmail.com") {
+  if (!token) {
+    return res.status(403).json("Not Authorized")
+  }
+
+  const userDoc = await firestore.collection("users").doc(token.uid).get()
+  const currentUser = getObject(userDoc) as User
+  if (!currentUser?.isAdmin) {
     return res.status(403).json("Not Authorized")
   }
   if (req.method === "GET" && (query === "producers" || query === "buyers")) {
@@ -28,20 +34,22 @@ const handler = async (req: NextApiRequest, res: NextApiResponse<string>) => {
     })
 
     const producersSnapshot = await firestore.collection("users").where("role", "==", role).get()
-    const producers = producersSnapshot.docs.map((doc) => {
-      const producer = getObject(doc) as Producer
-      return [
-        producer.siret,
-        producer.name,
-        producer.firstname,
-        producer.lastname,
-        producer.email,
-        producer.phone,
-        producer.address,
-        producer.created && formatISO9075(producer.created),
-        sums[producer.objectID] || 0,
-      ]
-    })
+    const producers = producersSnapshot.docs
+      .map((doc) => getObject(doc) as Producer)
+      .filter((producer) => !producer.isAdmin)
+      .map((producer) => {
+        return [
+          producer.siret,
+          producer.name,
+          producer.firstname,
+          producer.lastname,
+          producer.email,
+          producer.phone,
+          producer.address,
+          producer.created && formatISO9075(producer.created),
+          sums[producer.objectID] || 0,
+        ]
+      })
 
     try {
       const output = await getCsv(producers, [

--- a/src/pages/api/user.ts
+++ b/src/pages/api/user.ts
@@ -58,6 +58,7 @@ const handler = async (req: NextApiRequest, res: NextApiResponse<ApiResponse<Reg
   if (req.method === "POST") {
     // user registration
     const user = req.body as RegisteringUser // TODO: validate fields
+    delete (user as any).isAdmin
     if (user.role === USER_ROLE.PRODUCER) {
       user.siret = user.siret.replace(/\s+/g, "") // remove spaces
       const checkError = await checkCompany(user.siret, user.nocheck)
@@ -123,19 +124,25 @@ const handler = async (req: NextApiRequest, res: NextApiResponse<ApiResponse<Reg
     }
 
     const user = req.body as UpdatingUser // TODO: validate fields
+    // isAdmin and role must never be set via this public route (privilege escalation)
+    delete (user as any).isAdmin
+    delete (user as any).role
     user.updated = new Date()
-    if (user.role === USER_ROLE.PRODUCER) {
-      user.phone = normalizeNumber(user.phone)
-    }
 
     const usersCollection = firestore.collection("users")
     const userRef = usersCollection.doc(token.uid)
 
+    const userDoc = await userRef.get()
+    const userData = getObject(userDoc) as Producer
+    const isProducer = userData.role === USER_ROLE.PRODUCER
+
+    if (isProducer) {
+      user.phone = normalizeNumber(user.phone)
+    }
+
     const updates: Readonly<Promise<any>>[] = [userRef.update(user)]
 
-    if (user.role === USER_ROLE.PRODUCER) {
-      const userDoc = await userRef.get()
-      const userData = getObject(userDoc) as Producer
+    if (isProducer) {
       for (const uid in userData.followers) {
         updates.push(usersCollection.doc(uid).update({ [`followedProducers.${token.uid}.name`]: user.name }))
       }

--- a/src/types/model.d.ts
+++ b/src/types/model.d.ts
@@ -40,17 +40,15 @@ interface BaseUser extends Identified {
   email: string
   followedProducers: Record<string, FollowedProducer>
   role: USER_ROLE
+  isAdmin?: boolean
 }
 interface Buyer extends BaseUser {
   role: USER_ROLE.BUYER
 }
 
-interface Admin extends BaseUser {
-  role: USER_ROLE.ADMIN
-}
 interface Producer extends BaseUser {
   role: USER_ROLE.PRODUCER
-  siret: string
+  siret?: string
   name: string // company name
   address: string
   description: string
@@ -58,9 +56,10 @@ interface Producer extends BaseUser {
   followers?: Record<string, Follower>
   alertsExpired?: boolean
 }
-type User = Buyer | Producer | Admin
+type User = Buyer | Producer
 
-interface RegisteringUser extends Registering<Producer> {
+interface RegisteringUser extends Omit<Registering<Producer>, "siret"> {
+  siret: string
   created: Date
   password: string
   nocheck?: boolean


### PR DESCRIPTION
Ticket Trello : https://trello.com/c/o88aAi4f

## Résumé

L'implémentation du ticket #201 est terminée dans `/data/worktrees/201-securiser-acces-aux-donnees-des-producte` (7 fichiers modifiés, aucun commit fait comme demandé) :

- **`api/export.ts`** : le check email en dur est remplacé par une vérification du flag `isAdmin` en Firestore ; les comptes admin sont exclus de l'export "producteurs" pour ne pas polluer les données.
- **`api/user.ts`** : faille d'élévation de privilèges corrigée — `isAdmin` et `role` sont désormais retirés du payload client avant écriture Firestore (POST et PUT), le statut producteur pour le fan-out (followers/produits) est relu depuis Firestore plutôt que fait confiance au body.
- **`types/model.d.ts`** / **`constants/index.ts`** : rôle `ADMIN` supprimé, `isAdmin?: boolean` ajouté sur `BaseUser`, `siret` rendu optionnel sur `Producer` (avec `RegisteringUser` qui le garde obligatoire à l'inscription publique).
- **`auth.tsx`** : redirection spéciale admin→`/csv-export` supprimée (un admin suit désormais le parcours producteur standard) ; la route `/csv-export` reste protégée via `isAdmin`, y compris pour les visiteurs non connectés.
- **`header.tsx`** / **`UserZone.tsx`** : le bouton d'export est déplacé du header vers le menu dropdown, conditionné sur `isAdmin`.

`yarn tsc --skipLibCheck --noEmit` passe sans erreur, et aucune référence résiduelle à l'ancien rôle `ADMIN` ne subsiste. J'ai aussi simplifié une petite duplication de constante (`AUTH_ROUTES`/`ADMIN_ROUTES` identiques) laissée par l'agent d'implémentation.

Reste hors scope, à faire manuellement en Firestore : basculer `cilieff@gmail.com` en `role: PRODUCER` + `isAdmin: true` (avec nom/adresse/téléphone/description, sans SIRET), et créer `contact@leschouxdacote.fr` de la même façon — à coordonner avec le déploiement pour éviter une fenêtre où `cilieff@gmail.com` perd l'accès.

🤖 Generated with [Claude Code](https://claude.com/claude-code)